### PR TITLE
add mathjax support

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,6 +5,9 @@
   using the <a href="https://github.com/koirand/pulp/">pulp</a> theme.
   </p>
 </footer>
+{{ if .Params.mathjax }}
+    {{ partial "mathjax_support.html" . }}
+{{ end }}
 {{- range .Site.Params.custom_js -}}
 <script src="{{ . }}"></script>
 {{ end }}

--- a/layouts/partials/mathjax_support.html
+++ b/layouts/partials/mathjax_support.html
@@ -1,0 +1,19 @@
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script id="MathJax-script" async
+        src="https://cdn.jsdelivr.net/npm/mathjax@3.0.1/es5/tex-mml-chtml.js">
+</script>
+<script>
+MathJax.Hub.Config({
+  tex2jax: {
+    inlineMath: [['$','$'], ['\\(','\\)']],
+    displayMath: [['$$','$$'], ['\[','\]']],
+    processEscapes: true,
+    processEnvironments: true,
+    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre','code'],
+    TeX: {
+      equationNumbers: { autoNumber: "AMS" },
+      extensions: ["AMSmath.js", "AMSsymbols.js"]
+    }
+  }
+});
+</script>


### PR DESCRIPTION
Hi, I implemented the mathjax support according to this [blog](http://xuchengpeng.com/hexo-blog/2018/07/10/setting-mathjax-with-hugo/).

Add `mathjax: true` in the front matter to support mathjax in the post.