### PR TITLE
Remove google_news internal template.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,6 @@
 
   {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/gohugoio/hugo/tree/master/tpl/tplimpl/embedded/templates */}}
   {{- template "_internal/opengraph.html" . -}}
-  {{- template "_internal/google_news.html" . -}}
   {{- template "_internal/schema.html" . -}}
   <!-- {{- template "_internal/twitter_cards.html" . -}} -->
   {{- partial "twitter_cards.html" . -}}


### PR DESCRIPTION
Now the hugo command warns that google_news internal template should be removed. This PR removes the usage of google_news internal template based on the warning.

Please see https://github.com/gohugoio/hugo/issues/9172 for additional information.